### PR TITLE
change mrc-sim to roslaunch command

### DIFF
--- a/setup.bash
+++ b/setup.bash
@@ -81,7 +81,7 @@ else
   alias sshhero='ssh -A -X mrc@192.168.44.51'
   alias pyro-core='export ROS_MASTER_URI=http://192.168.44.122:11311'
   alias hero-core='export ROS_MASTER_URI=http://192.168.44.51:11311'
-  alias mrc-sim='rosrun emc_simulator pico_simulator'
+  alias mrc-sim='roslaunch emc_simulator sim.launch'
   alias mrc-viz='rosrun emc_system emc_viz'
   alias mrc-speech='rosrun pico_talk speech_server.py'
 fi


### PR DESCRIPTION
changed mrc-sim to use the new launch file to open the simulator, which also loads subscriber and publisher parameters