### PR TITLE
change mrc-viz alias

### DIFF
--- a/setup.bash
+++ b/setup.bash
@@ -82,6 +82,7 @@ else
   alias pyro-core='export ROS_MASTER_URI=http://192.168.44.122:11311'
   alias hero-core='export ROS_MASTER_URI=http://192.168.44.51:11311'
   alias mrc-sim='roslaunch emc_simulator sim.launch'
-  alias mrc-viz='rosrun emc_system emc_viz'
+  alias mrc-viz='roslaunch emc_simulator viz.launch'
+  #alias mrc-viz='rosrun emc_system emc_viz'
   alias mrc-speech='rosrun pico_talk speech_server.py'
 fi


### PR DESCRIPTION
Based on suggestions in https://github.com/tue-robotics/emc_simulator/pull/26, move rviz launch to a seperate file. Suggestion to use mrc-viz, since it is essentially a more powerful version of the original mrc-viz