### PR TITLE
add hostname

### DIFF
--- a/setup.bash
+++ b/setup.bash
@@ -1,8 +1,5 @@
 export EMC_ENV_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export EMC_DIR=$EMC_ENV_DIR/..
-
-# --------------------------------------------------------------------------------
-
 export EMC_SYSTEM_DIR=$EMC_DIR/system
 
 if [ -z "$EMC_ROS_DISTRO" ]
@@ -68,6 +65,7 @@ function emc-update
 }
 
 # --------------------------------------------------------------------------------
+export ROS_HOSTNAME=$HOSTNAME.local
 
 alias mrc-teleop='rosrun emc_system teleop.py'
 


### PR DESCRIPTION
will add hostnames as hostname.local. So we should only do this if we are sure that all our robots will follow this convention.